### PR TITLE
Link to internal fonts

### DIFF
--- a/css/icon-font.less
+++ b/css/icon-font.less
@@ -1,10 +1,10 @@
 @font-face {
 	font-family: 'icomoon';
-	src:url('https://raw.githubusercontent.com/jesseweed/seti-ui/master/css/_fonts/icomoon.eot?v0.0.1');
-	src:url('https://raw.githubusercontent.com/jesseweed/seti-ui/master/css/_fonts/icomoon.eot?v0.0.1') format('embedded-opentype'),
-		url('https://raw.githubusercontent.com/jesseweed/seti-ui/master/css/_fonts/icomoon.woff?v0.0.1') format('woff'),
-		url('https://raw.githubusercontent.com/jesseweed/seti-ui/master/css/_fonts/icomoon.ttf?v0.0.1') format('truetype'),
-		url('https://raw.githubusercontent.com/jesseweed/seti-ui/master/css/_fonts/icomoon.svg?v0.0.1') format('svg');
+	src:url('atom://seti-ui/css/_fonts/icomoon.eot');
+	src:url('atom://seti-ui/css/_fonts/icomoon.eot') format('embedded-opentype'),
+		url('atom://seti-ui/css/_fonts/icomoon.woff') format('woff'),
+		url('atom://seti-ui/css/_fonts/icomoon.ttf') format('truetype'),
+		url('atom://seti-ui/css/_fonts/icomoon.svg') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
Instead of getting Atom to request the fonts from the repo here on github get it to request them from the folder on the local machine.

This means that the theme will work even when the user is offline.
