### PR TITLE
Fix folder colours

### DIFF
--- a/css/icons.less
+++ b/css/icons.less
@@ -613,7 +613,7 @@
 // - - - - - - -
 
 // STATUS: ADDED
-.directory.entry.list-nested-item.status-added > .header.list-item:first-child {
+.directory.entry.list-nested-item.status-added > .header.list-item {
 
   // OPEN/CLOSE SELECTOR
   &:before {
@@ -654,7 +654,7 @@
 
 
 // STATUS: MODIFIED
-.directory.entry.list-nested-item.status-modified > .header.list-item:first-child {
+.directory.entry.list-nested-item.status-modified > .header.list-item {
 
   // OPEN/CLOSE SELECTOR
   &:before {


### PR DESCRIPTION
I had the issue where the whole folder was highlighted with changes/additions. This fixes it.

Before: 
![screen shot 2014-07-21 at 20 59 54](https://cloud.githubusercontent.com/assets/1273965/3649551/6e2a1e8a-1113-11e4-9985-9bedcb233a1f.png)
![screen shot 2014-07-21 at 21 03 38](https://cloud.githubusercontent.com/assets/1273965/3649552/6f85e246-1113-11e4-9659-c80ffaa3043c.png)

After:
![screen shot 2014-07-21 at 21 00 42](https://cloud.githubusercontent.com/assets/1273965/3649553/75bcc99a-1113-11e4-8fed-0398937dde0f.png)
![screen shot 2014-07-21 at 21 04 56](https://cloud.githubusercontent.com/assets/1273965/3649559/7ba4a742-1113-11e4-933a-0348fc2ae5fe.png)
