### PR TITLE
Add Open Sans for better Linux rendering

### DIFF
--- a/stylesheets/ui-variables.less
+++ b/stylesheets/ui-variables.less
@@ -128,4 +128,4 @@
 @overlay-background-color: #202123;
 @overlay-border-color: @background-color-highlight;
 
-@font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
+@font-family: 'Lucida Grande', 'Segoe UI', 'Open Sans', sans-serif;


### PR DESCRIPTION
Open Sans is a free humanist font available from Google (https://www.google.com/fonts/specimen/Open+Sans) and is available from most Linux package managers.

Seti UI looks kinda grungy on Linux without it, since the fallback after Segoe UI is the Liberation font family, which is not the best.
