### PR TITLE
#24 Fix text clip issue in command palette

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -68,6 +68,6 @@
   }
 
   .editor.editor-colors.mini.is-focused {
-    padding: 10px;
+    padding: 1px;
   }
 }


### PR DESCRIPTION
Not sure why the padding is `10px`. But that is obviously too wide, so the text got clipped.
Adjust the value to `1px` to put the text in the middle of the container.
