### PR TITLE
Fix Icon Positions

### DIFF
--- a/stylesheets/icons.less
+++ b/stylesheets/icons.less
@@ -223,6 +223,11 @@ default = '', '', 20px, 6px, 0px, -5px, -4px */
 .icon-tab('.md', 'md', 20px, 5px, -3px, -5px, -5px);
 .icon-tree('.md', 'md', 20px, 5px, 2px, -5px, -2px);
 
+// Override for Markdown package
+.tab-bar .tab .title.icon-markdown[data-name*=".md"] {
+  top: 0;
+}
+
 // Mustache
 .icon-tab('.mustache', 'mustache', 22px, 6px, 0px, -5px );
 .icon-tree('.mustache', 'mustache', 20px, 5px, 2px, -5px, -3px);

--- a/stylesheets/ui-mixins.less
+++ b/stylesheets/ui-mixins.less
@@ -36,7 +36,7 @@
     top: @offset;
     padding: 0;
 
-    &.icon-file-text, &.icon-file-media {
+    &.icon-file-text, &.icon-file-media, &.icon-book {
       &:before {
         font-family: icomoon;
         content: "@{icon-@{type}}";


### PR DESCRIPTION
This fixes a couple of things.

If my file name was `something.js.coffee` the JS logo would be present. 

Before:
![screen shot 2014-08-17 at 16 53 49](https://cloud.githubusercontent.com/assets/1273965/3945052/838bc424-2629-11e4-8c56-1a886cb930d9.png)
After:
![screen shot 2014-08-17 at 16 54 03](https://cloud.githubusercontent.com/assets/1273965/3945053/88a61ea0-2629-11e4-8cc2-3ebee9610615.png)

Also, fixed  the positioning of Coffee and Bower files in the tree view:

Before:
![screen shot 2014-08-14 at 15 01 42](https://cloud.githubusercontent.com/assets/1273965/3945056/9d431f34-2629-11e4-8a68-4a1c1ed8cf26.png)
After:
![screen shot 2014-08-17 at 17 15 10](https://cloud.githubusercontent.com/assets/1273965/3945057/b4696c4a-2629-11e4-9c9b-cc9aceabcf12.png)
