### PR TITLE
Match actual extension in .icon-tab() and .icon-tree()

### DIFF
--- a/stylesheets/ui-mixins.less
+++ b/stylesheets/ui-mixins.less
@@ -3,7 +3,7 @@
 
 .icon-tab( @extension: ''; @type: ''; @font: 20px; @top: 6px; @right: -3px; @left: -5px; @offset: -6px) {
 
-  .tab-bar .tab .title[data-name*="@{extension}"] {
+  .tab-bar .tab .title[data-name$="@{extension}"] {
     position: relative;
     display: inline-block;
     top: @offset;
@@ -21,7 +21,7 @@
     }
   }
 
-  .tab-bar .tab.active .title[data-name*="@{extension}"] {
+  .tab-bar .tab.active .title[data-name$="@{extension}"] {
     top: @offset;
   }
 
@@ -29,7 +29,7 @@
 
 .icon-tree( @extension: ''; @type: ''; @font: 20px; @top: 6px; @right: 0px; @left: -5px; @offset: -6px) {
 
-  .name.icon[data-name*="@{extension}"] {
+  .name.icon[data-name$="@{extension}"] {
 
     position: relative;
     display: inline-block;


### PR DESCRIPTION
Use the `$=` syntax instead of `*=` to match the extension against the end of the `data-name` value. This way the actual extension is matched rather than any part of the `data-name`.

I am not sure if there is any reason why you aren’t doing it this way. I didn’t see any breakage when I made this change to my local build.
