### PR TITLE
Emblem.js icon

### DIFF
--- a/file-types/Emblem.em
+++ b/file-types/Emblem.em
@@ -1,0 +1,1 @@
+.em or .emblem

--- a/stylesheets/icon-font.less
+++ b/stylesheets/icon-font.less
@@ -73,6 +73,9 @@
 .icon-icons_hbs:before {
 	content: "\e60f";
 }
+.icon-icons_emblem:before {
+	content: "\e61c";
+}
 .icon-icons_gulp:before {
 	content: "\e610";
 }

--- a/stylesheets/icon-variables.less
+++ b/stylesheets/icon-variables.less
@@ -13,6 +13,7 @@
 @icon-cson: '\e60b';
 @icon-css: '\e614';
 @icon-default: '\e612';
+@icon-emblem: '\e61c';
 @icon-grunt: '\e611';
 @icon-gulp: '\e610';
 @icon-handlebars: '\e60f';
@@ -42,6 +43,7 @@
 @color-bower: #F0582B; // BOWER
 @color-coffee: #a6814f; // COFFEE FILES
 @color-css: #29A8DE; // CSS
+@color-emblem: #1F6C9E; // Emblem.js
 @color-grunt: #FAA91A; // Grunt
 @color-gulp: #EE4845; // Gulp
 @color-handlebars: #E58824; // Mustache

--- a/stylesheets/icons.less
+++ b/stylesheets/icons.less
@@ -169,6 +169,12 @@ default = '', '', 20px, 6px, 0px, -5px, -4px */
 .icon-tab('.cson', 'json', 20px, 6px, -3px, -5px, -4px);
 .icon-tree('.cson', 'json', 20px, 5px, 2px, -5px, -4px);
 
+// Emblem.js
+.icon-tab('.em', 'emblem', 20px, 5px, 2px, -4px, -5px);
+.icon-tree('.em', 'emblem', 20px, 5px, 2px, -4px, -3px);
+.icon-tab('.emblem', 'emblem', 20px, 5px, 2px, -4px, -5px);
+.icon-tree('.emblem', 'emblem', 20px, 5px, 2px, -4px, -3px);
+
 // Handlebars
 .icon-tab('.hbs', 'handlebars', 22px, 6px, 0px, -5px );
 .icon-tree('.hbs', 'handlebars', 20px, 5px, 2px, -5px, -3px);


### PR DESCRIPTION
I don't really know how icon fonts work, so I left everything as it was and ask you to add the icon to the font.

I've "registered" the icon at `\e61c`. If you want a different code, I'll change it.

The icon assets can be found [here](https://github.com/machty/emblem.js/issues/174#issuecomment-59635569). The icon is subject to discussion (though the project leader already likes it), so you may want to wait a few days.

Thank you for making such an awesome theme!