### PR TITLE
Fixed invalid background-color value.

### DIFF
--- a/stylesheets/editor.less
+++ b/stylesheets/editor.less
@@ -59,7 +59,7 @@ atom-text-editor::shadow .gutter.drop-shadow {
 
 @-webkit-keyframes highlight {
   from { background-color: rgba(100, 255, 100, 0.7); }
-  to { background-color: null; }
+  to { background-color: transparent; }
 }
 
 atom-text-editor .highlighted.selection .region,


### PR DESCRIPTION
I have not been able to test this but when I read the css I saw this and assumed you wanted `transparent`, as `null` is an invalid CSS value of `background-color`.