### PR TITLE
Remove /deep/ modifier until alternative found.

### DIFF
--- a/stylesheets/atom.less
+++ b/stylesheets/atom.less
@@ -9,17 +9,17 @@ atom-workspace {
 }
 
 .scrollbars-visible-always {
-  /deep/ ::-webkit-scrollbar {
+  ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
-  /deep/ ::-webkit-scrollbar-track,
-  /deep/ ::-webkit-scrollbar-corner {
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
     background: @scrollbar-background-color;
   }
 
-  /deep/ ::-webkit-scrollbar-thumb {
+  ::-webkit-scrollbar-thumb {
     background: @scrollbar-color;
     border-radius: 5px;
     box-shadow: 0 0 1px black inset;


### PR DESCRIPTION
The `/deep/` modifier breaks some less compilers, which in turn breaks the
entire stylesheet. This returns the less to a usable state until a suitable
alternative to `/deep/` is found.

Closes #70 