### PR TITLE
Improve settings

### DIFF
--- a/index.less
+++ b/index.less
@@ -15,6 +15,7 @@
 @import "stylesheets/tooltips";
 @import "stylesheets/tree-view";
 @import "stylesheets/utilities";
+@import "stylesheets/settings";
 
 .icons(@icons) when (@icons = true) {
   @import "stylesheets/icons";

--- a/stylesheets/buttons.less
+++ b/stylesheets/buttons.less
@@ -42,7 +42,8 @@
   .btn-background(@bg, @hover, @selected, @text-color-highlight);
 }
 
-.btn {
+.btn,
+.btn.icon {
   .btn-background(@button-background-color, @button-background-color-hover, @button-background-color-selected, @text-color);
 }
 

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -1,7 +1,18 @@
 @import "ui-variables";
 
 .settings-view {
+
   select.form-control {
     border: none;
   }
+
+  atom-text-editor .placeholder-text, // <-- deprecated
+  atom-text-editor::shadow .placeholder-text {
+    color: lighten(@text-color-subtle, 15%);
+  }
+
+  .available-package-view .meta-user .author {
+    color: lighten(@text-color-subtle, 10%);
+  }
+
 }

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -1,0 +1,7 @@
+@import "ui-variables";
+
+.settings-view {
+  select.form-control {
+    border: none;
+  }
+}

--- a/stylesheets/settings.less
+++ b/stylesheets/settings.less
@@ -4,6 +4,7 @@
 
   select.form-control {
     border: none;
+    color: @text-color-selected;
   }
 
   atom-text-editor .placeholder-text, // <-- deprecated


### PR DESCRIPTION
This PR is in anticipation of these changes https://github.com/atom/settings-view/pull/277 in the settings. __tl;dr:__ The settings will use the `ui-variables` and match a theme's look and feel.

There isn't much to do for themes, but this PR still adds a couple improvements. Like:

## Before

![screen shot 2014-12-18 at 9 53 31 am](https://cloud.githubusercontent.com/assets/378023/5483250/340d3772-86b2-11e4-9fe4-c237362effdb.png)

![screen shot 2014-12-18 at 11 05 47 am](https://cloud.githubusercontent.com/assets/378023/5483255/435067ea-86b2-11e4-8b27-4aae2fd094fc.png)

## After

![screen shot 2014-12-18 at 10 43 16 am](https://cloud.githubusercontent.com/assets/378023/5483253/3c731e40-86b2-11e4-9524-1658997751b9.png)

![screen shot 2014-12-18 at 11 06 00 am](https://cloud.githubusercontent.com/assets/378023/5483257/4ec55b76-86b2-11e4-8c72-10f0a0a1d70c.png)

ps. This part https://github.com/simurai/seti-ui/blob/fe45bccf324a5b02b370bb5cfb4b51bc6245b081/stylesheets/settings.less#L9-L16 might not be needed if the overal `@text-color-subtle` would be a bit lighter.