### PR TITLE
Fixed settings tab title position

### DIFF
--- a/stylesheets/icons.less
+++ b/stylesheets/icons.less
@@ -144,7 +144,7 @@ default = '', '', 20px, 6px, 0px, -5px, -4px */
 tabs-bar tabs-tab .title.icon-tools, .tab-bar .tab .title.icon-tools {
   position: relative;
   display: inline-block;
-  top: 2px;
+  top: 1px;
   padding: 0;
   width: 100%;
 


### PR DESCRIPTION
The settings tab title is misaligned by 1px. And that really bothers me a lot. (I know, it's dumb, but I hate even the slightest inaccuracies like this one)
![align](https://cloud.githubusercontent.com/assets/3685659/6765384/ff97f020-cfdd-11e4-9f9e-36628a9a2a4a.png)
