### PR TITLE
Make tip-of-the-day messages legible

### DIFF
--- a/stylesheets/messages.less
+++ b/stylesheets/messages.less
@@ -1,6 +1,9 @@
 @import "ui-variables";
 
 ul.background-message {
+  margin: 0 10%;
+
   font-weight: bold;
-  color: rgba(0, 0, 0, .2);
+  color: darken(@text-color-subtle, 5%);
+  text-shadow: 1px 1px 0 darken(@text-color-subtle, 25%);
 }


### PR DESCRIPTION
Before:
![screen shot 2015-04-06 at 4 11 53 pm](https://cloud.githubusercontent.com/assets/1399532/7015429/8c3e5184-dc88-11e4-8e93-a031ac9cc224.png)

After:
![screen shot 2015-04-06 at 4 17 44 pm](https://cloud.githubusercontent.com/assets/1399532/7015431/9367ac44-dc88-11e4-8f10-4e22bf157790.png)

Just making the message a little easier to read.