### PR TITLE
Fixed some issues with the tab bar

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -15,7 +15,6 @@
 tabs-bar, .tab-bar {
   height: @tab-height + @tab-top-padding + @tab-bottom-border-height;
   background: @tab-bar-background-color;
-  padding: 0 10px 0 10px;
   box-sizing: border-box;
   border-bottom: solid 4px @tab-bar-bottom-border-color;
   // left: 16px;
@@ -36,8 +35,7 @@ tabs-bar, .tab-bar {
     height: @tab-height;
     line-height: @tab-height;
     color: @text-color;
-    padding-left: 0;
-    margin-left: 15px;
+    padding-left: 15px;
     border-radius: 0;
     box-shadow: none;
     -webkit-transform: none;
@@ -46,28 +44,8 @@ tabs-bar, .tab-bar {
     border-radius: 0;
     border: none;
     border-bottom: solid 4px @tab-bar-bottom-border-color;
-
-    &, &:before {
-      background: @tab-background;
-    }
-
-    &:before {
-      background: @tab-background;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -16px;
-      height: @tab-height;
-      width: 16px;
-      border-radius: 0;
-      border-top-right-radius: 0;
-      -webkit-transform: none;
-      border: none;
-      border-bottom: solid 4px @tab-bar-bottom-border-color;
-      border-left: solid 1px @tab-bar-bottom-border-color;
-      box-shadow: none;
-    }
-
+    border-right: solid 1px @tab-bar-bottom-border-color;
+    background: @tab-background;
 
     .close-icon {
       z-index: 3;
@@ -96,8 +74,8 @@ tabs-bar, .tab-bar {
       margin-top: -2px;
     }
 
-    &:first-child {
-      margin-left: 0px;
+    &:last-child:not(.active) {
+      margin-right: -1px;
     }
   }
 
@@ -108,6 +86,8 @@ tabs-bar, .tab-bar {
     box-shadow: none;
     border: none;
     border-bottom: solid 4px @tab-highlight-color;
+    background: @tab-background-active;
+    height: @tab-height + 0px;
 
     .title{
       position: relative;
@@ -118,6 +98,7 @@ tabs-bar, .tab-bar {
     .close-icon {
       line-height: @tab-height - 1px;
       color: @text-color;
+      margin-right: 1px;
     }
 
     &, &:before {


### PR DESCRIPTION
* Tabs werent aligning properly with the left edge of the window. Most noticeable when you have multiple panes open.
* The :before element on the tabs was causing the cursor to spaz out when dragging the tabs around. I couldn't find any reason for having the pseudo element there so I removed it and replaced it with padding, fixing the cursor jumping and simplifying the css a bit.
* Some positioning tweaks on the .close-icon element too.