### PR TITLE
Alias .es and .es6 to js

### DIFF
--- a/styles/icons.less
+++ b/styles/icons.less
@@ -202,6 +202,10 @@ tabs-bar tabs-tab .title.icon-tools, .tab-bar .tab .title.icon-tools {
 // JavaScript
 .icon-tab('.js', 'js', 20px, 6px, -3px, -5px, -5px);
 .icon-tree('.js', 'js', 20px, 6px, 2px, -6px, -4px);
+.icon-tab('.es', 'js', 20px, 6px, -3px, -5px, -5px);
+.icon-tree('.es', 'js', 20px, 6px, 2px, -6px, -4px);
+.icon-tab('.es6', 'js', 20px, 6px, -3px, -5px, -5px);
+.icon-tree('.es6', 'js', 20px, 6px, 2px, -6px, -4px);
 
 // Coffescript
 .icon-tab('.coffee', 'coffee', 16px, 5px, 4px, 2px, -3px);


### PR DESCRIPTION
Alias `.es` and `.es6` extensions to `javascript`