### PR TITLE
Limit CPU usage of <progress> elements

### DIFF
--- a/styles/progress.less
+++ b/styles/progress.less
@@ -57,7 +57,7 @@ progress::-webkit-progress-bar {
   border-radius: 2px;
   background-size: 25px @progress-height, 100% 100%, 100% 100%;
   -webkit-animation: animate-stripes 5s linear infinite;
-  animation: animate-stripes 5s linear infinite;
+  animation: animate-stripes 5s linear 6; // stop animation after 6 runs (30s) to limit CPU usage
 }
 
 progress::-webkit-progress-value {
@@ -68,7 +68,7 @@ progress::-webkit-progress-value {
 
 progress[value]::-webkit-progress-bar {
   background-image: @progress-shine-gradient;
-  animation: none;
+  -webkit-animation: none;
 }
 
 @-webkit-keyframes animate-stripes {


### PR DESCRIPTION
The animation of the `<progress>` element can make the CPU spike a bit, this PR:

- Limits the buffering animation to only 30s, see https://github.com/atom/atom/issues/6646#issuecomment-130350092
- Adds a `-webkit-` prefix to properly remove the animation, see issue https://github.com/atom/atom-dark-ui/pull/49