### PR TITLE
Change header positioning to support top-aligned tool-bar

### DIFF
--- a/styles/sidebar/header.less
+++ b/styles/sidebar/header.less
@@ -10,8 +10,12 @@
   & > .header {
     position: fixed;
     right: 0;
-    top: 0;
+    margin-top: -@top-bar;
     z-index: 2;
+
+	&.seti-compact {
+	    margin-top: -@top-bar-small;
+	}
   }
 }
 


### PR DESCRIPTION
When you use the tool-bar package (https://atom.io/packages/tool-bar) with a top-aligned toolbar the toolbar isn't visible because the seti-ui header has a fixed top position at 0px. This change uses a margin-top to position the header so the toolbar will be visible in the right manner.