### PR TITLE
Remove button in.btn selector

### DIFF
--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -1,4 +1,4 @@
-button.btn {
+.btn {
   background-color: @grey;
   color: @white;
   transition: background 0.3s;


### PR DESCRIPTION
As noticed with abe33/atom-tablr#50 since the button's rule is defined using `button.btn` it's not possible to neither extend the style in less nor to apply a button style to another type of node. I feel this should not be enforced by the theme since there's some case where a button can't be used.

In my case I'm making `label` following a `input[type="radio"]` extend `.btn` to create a toggle buttons bar in the CSV settings: 

![](https://raw.githubusercontent.com/abe33/atom-tablr/gh-pages/csv-opener.png)
https://github.com/abe33/atom-tablr/blob/master/styles/tablr.less#L920-L922