### PR TITLE
Fix Linter rule link badge

### DIFF
--- a/styles/plugins/linter.less
+++ b/styles/plugins/linter.less
@@ -5,6 +5,11 @@
   }
 }
 
+.linter-message-item .badge {
+  background: @seti-primary-text;
+  color: @seti-primary;
+}
+
 linter-panel {
   .badge {
     color: @white;


### PR DESCRIPTION
How's this? The text is colored with the primary color. I didn't want to make it the same as the "ESLint" badge.

<img width="406" alt="screen shot 2016-05-03 at 17 34 21" src="https://cloud.githubusercontent.com/assets/471278/14988794/c78eb46a-1155-11e6-8611-bb636c3f9488.png">

Fixes #237.