### PR TITLE
Fix tab close button in compact mode

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -117,7 +117,7 @@ atom-workspace-axis.vertical .tab-bar {
 
     .modified {
       .close-icon {
-        top: 1px;
+        top: 11px;
         right: 5px;
       }
 


### PR DESCRIPTION
Before:
<img width="193" alt="screen shot 2016-05-03 at 17 51 02" src="https://cloud.githubusercontent.com/assets/471278/14989420/01a2adda-1158-11e6-8e72-6b5a75b75df3.png">

After:
<img width="195" alt="screen shot 2016-05-03 at 17 51 14" src="https://cloud.githubusercontent.com/assets/471278/14989427/08bb705c-1158-11e6-914a-2166a059370a.png">


Fixes #257.