### PR TITLE
Make tree highlight color more distinct

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -58,7 +58,7 @@
 // SIDEBAR
 @tree-view-background-color: lighten(@black, 3%);
 @tree-view-border-color: @base-border-color;
-@tree-view-highlight: @black;
+@tree-view-highlight: lighten(@black, 15%);
 @tree-view-header-color: #090b0d;
 @tree-view-header-text-color: @white;
 @tree-view-text-color: @white;


### PR DESCRIPTION
Before:
<img width="265" alt="screen shot 2016-05-03 at 18 03 31" src="https://cloud.githubusercontent.com/assets/471278/14989710/740acd2a-1159-11e6-9e79-e7d5707b5232.png">

After:
<img width="266" alt="screen shot 2016-05-03 at 18 03 19" src="https://cloud.githubusercontent.com/assets/471278/14989716/7899c2ec-1159-11e6-90b6-1da93a6de652.png">

Fixes #258.