### PR TITLE
Add sticky project root headers

### DIFF
--- a/lib/headers.coffee
+++ b/lib/headers.coffee
@@ -1,0 +1,38 @@
+atom.packages.activatePackage('tree-view').then (tree) ->
+  IS_ANCHORED_CLASSNAME = 'is--anchored'
+
+  treeView = tree.mainModule.treeView
+  projectRoots = treeView.roots
+
+  updateTreeViewHeaderPosition = ->
+    yScrollPosition = treeView.scroller[0].scrollTop
+
+    for project in projectRoots
+      projectHeaderHeight = project.header.offsetHeight
+      projectClassList = project.classList
+      projectOffsetY = project.offsetTop
+      projectHeight = project.offsetHeight
+
+      if yScrollPosition > projectOffsetY
+        if yScrollPosition > projectOffsetY + projectHeight - projectHeaderHeight
+          project.header.style.top = 'auto'
+          projectClassList.add IS_ANCHORED_CLASSNAME
+        else
+          project.header.style.top = (yScrollPosition - projectOffsetY) + 'px'
+          projectClassList.remove IS_ANCHORED_CLASSNAME
+      else
+        project.header.style.top = '0'
+        projectClassList.remove IS_ANCHORED_CLASSNAME
+
+  atom.project.onDidChangePaths ->
+    projectRoots = treeView.roots
+    updateTreeViewHeaderPosition()
+
+  atom.config.onDidChange 'seti-ui', ->
+    # TODO something other than setTimeout? it's a hack to trigger the update
+    # after the CSS changes have occurred. a gamble, probably inaccurate
+    setTimeout -> updateTreeViewHeaderPosition()
+  treeView.scroller.on 'scroll', updateTreeViewHeaderPosition
+
+  setTimeout -> # TODO something other than setTimeout?
+    updateTreeViewHeaderPosition()

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -1,5 +1,6 @@
 Dom = require('./dom')
 Utility = require('./utility')
+Headers = require('./headers')
 
 module.exports =
   init: (state) ->

--- a/styles/sidebar/header.less
+++ b/styles/sidebar/header.less
@@ -27,6 +27,8 @@ atom-panel-container {
     top: 0;
     z-index: 1;
 
+    will-change: top, position;
+
     &:hover {
       background: #000;
       cursor: pointer;

--- a/styles/sidebar/header.less
+++ b/styles/sidebar/header.less
@@ -7,15 +7,24 @@ atom-panel-container {
      }
   }
 
+  // PROJECT ROOT
+  .project-root {
+    padding-top: @top-bar;
+    position: relative;
+  }
+
   // PROJECT HEADER
   .project-root > .header {
     background: @tree-view-header-color;
     color: @tree-view-header-text-color;
     font-size: 15px;
     font-weight: 300;
+    width: 100%;
     height: @top-bar;
     left: 0;
     padding: 15px 0 0 8px;
+    position: absolute;
+    top: 0;
     z-index: 1;
 
     &:hover {
@@ -52,13 +61,20 @@ atom-panel-container {
       }
     }
   }
-}
 
+  // ANCHORED PROJECT HEADER
+  .project-root.is--anchored > .header {
+    position: absolute;
+    top: auto; bottom: 0;
+  }
+}
 
 // COMPACT MODE
 atom-workspace.seti-compact {
   atom-panel-container {
-    .project-root:first-child {
+    .project-root {
+      padding-top: @top-bar-small;
+
       & > .header {
         font-size: 13px;
         height: @top-bar-small;


### PR DESCRIPTION
Fixes #263

Ended up not using `position: fixed` at all, but rather using `position: absolute` and calculating the top offset on scroll. Looks pretty nice, but is probably not that efficient. I tried to amend any possible lag with `will-change`, but I am unable to test this out on anything other than a 2014 MacBook Pro.

If it turns out it's lagging, adding a `requestAnimationFrame` layer might help.