### PR TITLE
Add selector to target sidebar for default icons

### DIFF
--- a/styles/icons/sidebar.less
+++ b/styles/icons/sidebar.less
@@ -13,8 +13,10 @@
   }
 }
 
-.file .icon {
-  .icon('default', @grey);
+atom-panel-container > atom-panel {
+  .file .icon {
+    .icon('default', @grey);
+  }
 }
 
 .entries.list-tree {


### PR DESCRIPTION
This is to address #301.

Looking for feedback on if this is the best way to solve it. I tried getting more specific with something like `.tree-view` but then it made all the icons default.

Any ideas if there is a better solution @jesseweed?