### PR TITLE
todo-show: Changed preview settings icons background colors

### DIFF
--- a/index.less
+++ b/index.less
@@ -27,3 +27,4 @@
 @import "styles/plugins/terminal-plus";
 @import "styles/plugins/time-cop";
 @import "styles/plugins/tree-view-git-branch";
+@import "styles/plugins/todo-show";

--- a/styles/plugins/todo-show.less
+++ b/styles/plugins/todo-show.less
@@ -1,0 +1,11 @@
+.show-todo-preview {
+  .badge {
+    background: @seti-primary;
+    color: @seti-primary-text;
+  }
+
+  code {
+    background: @seti-primary;
+    color: @seti-primary-text;
+  }
+}


### PR DESCRIPTION
The preview settings looked like this
![image](https://cloud.githubusercontent.com/assets/4412564/18535614/0e909c22-7acc-11e6-8f8b-fd08e721e7f0.png)

It was changed to look like this (with the color being the user selecte seti color)
![image](https://cloud.githubusercontent.com/assets/4412564/18535597/dc12be74-7acb-11e6-9bfc-fe4484c9f000.png)
