### PR TITLE
fixing typo in README to uninstall in development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Anyone is welcome to contribute to the development of this theme. If can be a lo
 ### 1. Fork
 If you're keen to contribute, start by [forking](https://github.com/jesseweed/seti-ui/tree/1.0-beta#fork-destination-box) the repo and cloning it to your computer.
 
-**Note:** To use the development version, you must first install the production version (`apm uninstall seti-ui`), then and run the following commands:
+**Note:** To use the development version, you must first uninstall the production version (`apm uninstall seti-ui`), then and run the following commands:
 
 ```bash
 # To install the local version as an Atom Theme


### PR DESCRIPTION
If I understand the procedure correctly, it seems the README has a small typo to install the development version by installing the production version (immediately followed by the command to uninstall the production version).

Just added the 'un' to make sure the text matches the instructions.