### PR TITLE
Added github icon mapping for .gitmodules file

### DIFF
--- a/styles/icons/mapping.less
+++ b/styles/icons/mapping.less
@@ -65,6 +65,7 @@
 .icon-set('.gitconfig', 'github', @white);
 .icon-set('.gitkeep', 'github', @white);
 .icon-set('.gitattributes', 'github', @white);
+.icon-set('.gitmodules', 'github', @white);
 
 // GO
 .icon-set('.go', 'go2', @blue);


### PR DESCRIPTION
By default we've github icon only for 4 files: .gitignore, .gitconfig, .gitkeep and .gitattributes. The .gitmodules file provides sensible default URLs for each submodule. So I've added this mapping.