### PR TITLE
Futureproof theme against impending jQuery removal

### DIFF
--- a/lib/headers.coffee
+++ b/lib/headers.coffee
@@ -5,7 +5,7 @@ atom.packages.activatePackage('tree-view').then (tree) ->
   projectRoots = treeView.roots
 
   updateTreeViewHeaderPosition = ->
-    yScrollPosition = treeView.scroller[0].scrollTop
+    yScrollPosition = (treeView.scroller[0] ? treeView.scroller).scrollTop
 
     for project in projectRoots
       projectHeaderHeight = project.header.offsetHeight
@@ -32,7 +32,11 @@ atom.packages.activatePackage('tree-view').then (tree) ->
     # TODO something other than setTimeout? it's a hack to trigger the update
     # after the CSS changes have occurred. a gamble, probably inaccurate
     setTimeout -> updateTreeViewHeaderPosition()
-  treeView.scroller.on 'scroll', updateTreeViewHeaderPosition
+  if typeof treeView.scroller.on is 'function'
+    treeView.scroller.on 'scroll', updateTreeViewHeaderPosition
+  else
+    treeView.scroller.addEventListener 'scroll', ->
+      updateTreeViewHeaderPosition()
 
   setTimeout -> # TODO something other than setTimeout?
     updateTreeViewHeaderPosition()


### PR DESCRIPTION
The `tree-view` package is [going to drop jQuery](https://github.com/atom/tree-view/pull/1032), which means trying to call `treeView.scroller.on` or access properties of `treeView.scroller[0]` will cause breakage at startup.

I've fixed it in advance for you.