### PR TITLE
Fix icon margin in tabs

### DIFF
--- a/styles/icons/tabs.less
+++ b/styles/icons/tabs.less
@@ -3,7 +3,8 @@
   // SET ICON SIZE
   .title::before {
     float: left;
-    font-size: 22px;
+    margin-top: 10px;
+    font-size: 24px;
     margin-right: 1px;
     line-height: 17px;
   }

--- a/styles/user-theme.less
+++ b/styles/user-theme.less
@@ -1,1 +1,1 @@
-@seti-primary: @purple;@seti-primary-text: @purple-text;@seti-primary-highlight: @purple-highlight;
+@seti-primary: @green;@seti-primary-text: @green-text;@seti-primary-highlight: @green-highlight;


### PR DESCRIPTION
Fix annoying icon displacement in tabs.  

|Early|Now|
|-----|---|
|![early](https://cloud.githubusercontent.com/assets/5213001/22869515/b10ac27c-f1da-11e6-9295-0810985dd05f.PNG)|![now](https://cloud.githubusercontent.com/assets/5213001/22869516/b10d62de-f1da-11e6-8fd9-8d653766efcb.PNG)|

#362 #387 referenced issues