### PR TITLE
Added ESLint icon mapping for .eslintignore file

### DIFF
--- a/styles/icons/mapping.less
+++ b/styles/icons/mapping.less
@@ -343,6 +343,7 @@
 
 // ESLINT
 .icon-set('.eslintrc', 'eslint', @purple);
+.icon-set('.eslintignore', 'eslint', @purple);
 
 // GRUNT
 .icon-set('Gruntfile.js', 'grunt', @orange);


### PR DESCRIPTION
Added missing mapping for .eslintignore file. The .eslintignore file is a plain text file where each line is a glob pattern indicating which paths should be omitted from linting.