### PR TITLE
Add all supported eslint config files to file icons

### DIFF
--- a/styles/icons/mapping.less
+++ b/styles/icons/mapping.less
@@ -353,6 +353,10 @@
 
 // ESLINT
 .icon-set('.eslintrc', 'eslint', @purple);
+.icon-set('.eslintrc.js', 'eslint', @purple);
+.icon-set('.eslintrc.yaml', 'eslint', @purple);
+.icon-set('.eslintrc.yml', 'eslint', @purple);
+.icon-set('.eslintrc.json', 'eslint', @purple);
 .icon-set('.eslintignore', 'eslint', @purple);
 
 // GRUNT


### PR DESCRIPTION
As use of the extensionless `.eslintrc` file is deprecated, but I still want my awesome eslint icon, this adds all supported config file formats.