### PR TITLE
Making sure we don't call scrollTop on undefined scroller. 

### DIFF
--- a/lib/headers.coffee
+++ b/lib/headers.coffee
@@ -5,7 +5,10 @@ atom.packages.activatePackage('tree-view').then (tree) ->
   projectRoots = treeView.roots
 
   updateTreeViewHeaderPosition = ->
-    yScrollPosition = (treeView.scroller[0] ? treeView.scroller).scrollTop
+    # Sometimes scroller ends up being undefined???
+    # https://github.com/jesseweed/seti-ui/issues/424
+    scroller = treeView.scroller?[0] ? treeView.scroller
+    yScrollPosition = scroller?.scrollTop || 0
 
     for project in projectRoots
       projectHeaderHeight = project.header.offsetHeight


### PR DESCRIPTION
Hopefully this'll fix #424 :+1: 

Couldn't replicate the issue when using `apm link`, but made these changes to the installed package and it stopped the error message from appearing.