### PR TITLE
Modify mapping so that Git files use the Git icon

### DIFF
--- a/styles/icons/mapping.less
+++ b/styles/icons/mapping.less
@@ -88,11 +88,11 @@
 .icon-set('.fsx', 'f-sharp', @blue);
 
 // GITIGNORE
-.icon-set('.gitignore', 'github', @white);
-.icon-set('.gitconfig', 'github', @white);
-.icon-set('.gitkeep', 'github', @white);
-.icon-set('.gitattributes', 'github', @white);
-.icon-set('.gitmodules', 'github', @white);
+.icon-set('.gitignore', 'git_ignore', @white);
+.icon-set('.gitconfig', 'git_ignore', @white);
+.icon-set('.gitkeep', 'git_ignore', @white);
+.icon-set('.gitattributes', 'git_ignore', @white);
+.icon-set('.gitmodules', 'git_ignore', @white);
 
 // GO
 .icon-set('.go', 'go2', @blue);

--- a/styles/icons/tabs.less
+++ b/styles/icons/tabs.less
@@ -23,7 +23,7 @@
 
   // NEW FILES
   &[data-type='GitControlView'] .title:not([data-name]) {
-    .icon('github', @seti-primary);
+    .icon('git_ignore', @seti-primary);
   }
 
   // NEW FILES

--- a/styles/plugins/tree-view-git-branch.less
+++ b/styles/plugins/tree-view-git-branch.less
@@ -30,7 +30,7 @@ atom-panel-container.left, atom-panel-container.right {
             height: 30px;
 
             .name.icon {
-              .icon('github', darken(@tree-view-text-color, 50%));
+              .icon('git_ignore', darken(@tree-view-text-color, 50%));
               padding: 0;
               line-height: 16px;
             }


### PR DESCRIPTION
The Git software project is actually not the same as the GitHub hosting
service. Since the icon set already contains the official Git logo, the
mapping should be modified to use those icons instead of the GitHub
icon.

Fixes #341 

Before:
![screenshot from 2017-05-26 17-24-41](https://cloud.githubusercontent.com/assets/472350/26514576/48973b18-4238-11e7-8332-e85460ead43a.png)

After:
![screenshot from 2017-05-26 17-20-06](https://cloud.githubusercontent.com/assets/472350/26514581/4cedb0a2-4238-11e7-86b6-460aea4e5f46.png)
