### PR TITLE
Add .md and .txt variants for LICENSE

### DIFF
--- a/styles/icons/mapping.less
+++ b/styles/icons/mapping.less
@@ -436,6 +436,8 @@
 
 // LICENSE FILES
 .icon-partial('LICENSE', 'license', @yellow);
+.icon-partial('LICENSE.md', 'license', @yellow
+.icon-partial('LICENSE.txt', 'license', @yellow
 .icon-partial('LICENCE', 'license', @yellow);
 .icon-partial('COPYING', 'license', @yellow);
 .icon-partial('COMPILING', 'license', @orange);


### PR DESCRIPTION
Some licenses make official copies available and Markdown and this repository even uses `LICENSE.md`.
`LICENSE.txt` is popular in some circles, especially with developers on Windows.

Relevant, #300 