### PR TITLE
Fix wrong colour applied to selected button icons

### DIFF
--- a/styles/components/find-replace.less
+++ b/styles/components/find-replace.less
@@ -38,6 +38,10 @@
         background-color: lighten(@bad, 10%);
       }
     }
+    .btn.selected > .icon {
+      fill: @white;
+      stroke: @white;
+    }
   }
 
 }

--- a/styles/user-theme.less
+++ b/styles/user-theme.less
@@ -1,1 +1,1 @@
-@seti-primary: @purple;@seti-primary-text: @purple-text;@seti-primary-highlight: @purple-highlight;
+@seti-primary: @blue;@seti-primary-text: @blue-text;@seti-primary-highlight: @blue-highlight;


### PR DESCRIPTION
Fixes jesseweed/seti-syntax#152, which I noticed while preparing [`seti-syntax#156`](https://github.com/jesseweed/seti-syntax/pull/156).

Pretty self-explanatory, =)