### PR TITLE
Add docker-compose.yaml highlight as docker file

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -390,6 +390,7 @@
 .icon-partial('.dockerignore', 'docker', @grey);
 .icon-partial('docker-healthcheck', 'docker', @green);
 .icon-partial('docker-compose.yml', 'docker', @pink);
+.icon-partial('docker-compose.yaml', 'docker', @pink);
 
 
 // BABEL


### PR DESCRIPTION
In https://docs.docker.com/compose/compose-file/#service-configuration-reference you can find next:
>Tip: You can use either a .yml or .yaml extension for this file. They both work.

Because many of developers use `.yaml` extension instead `.yml`, it's good idea add highlight for both variant.

P.S. I was redirected to you repo from https://github.com/Microsoft/vscode/pull/32414