### PR TITLE
No offset when "Project" tab in treeview is hidden

### DIFF
--- a/styles/components/dock.less
+++ b/styles/components/dock.less
@@ -23,12 +23,26 @@ atom-workspace.hide-title-bar {
 }
 
 atom-workspace.hide-project-tab {
+
   // SINGLE TAB
   .tab {
     &[data-type="TreeView"] {
       display: none;
     }
   }
+
+  &:not(.seti-compact) {
+    .tool-panel.tree-view {
+      top: -1 * @top-bar;
+    }
+  }
+  
+  &.seti-compact {
+    .tool-panel.tree-view {
+      top: -1 * @top-bar-small;
+    }
+  }
+
 }
 
 // COMPACT


### PR DESCRIPTION
When the project tab was disabled the space for it was still remaining. Now the tree view fills the whole panel if the tab is hidden.