### PR TITLE
Added .tfvars to mapping.less

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -271,6 +271,7 @@
 // TERRAFORM
 .icon-set('.tf', 'terraform', @purple);
 .icon-set('.tf.json', 'terraform', @purple);
+.icon-set('.tfvars', 'terraform', @purple);
 
 // TEX
 .icon-set('.tex', 'tex', @blue);


### PR DESCRIPTION
This adds the Terraform .tfvars extension to Terraform group on mapping.less.  The extension .tfvars is a common Terraform extension (https://www.terraform.io/intro/getting-started/variables.html#from-a-file).