### PR TITLE
Define @font-family

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -156,6 +156,7 @@
 
 // MISC
 @seti-font-family: 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+@font-family: 'Roboto', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
 @font-size: 12px;
 @disclosure-arrow-size: 12px;
 


### PR DESCRIPTION
@jesseweed This variable is supposed to be defined by all themes (see https://github.com/atom/atom/blob/master/static/variables/ui-variables.less#L84), and fixes the issue reported in https://github.com/facebook-atom/atom-ide-ui/issues/14. The latest version of atom-ide-ui is breaking for me because it assumes the existence of this variable.