### PR TITLE
Add a different color for Typescript unit tests

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -289,6 +289,7 @@
 
 // TYPESCRIPT
 .icon-set('.ts', 'typescript', @blue);
+.icon-set('.spec.ts', 'typescript', @yellow);
 
 // VALA
 .icon-set('.vala', 'vala', @grey-light);


### PR DESCRIPTION
I propose we visually differentiate Typescript unit test files `.spec.ts` with the same icon, but a different color.  Yellow was chosen as it's a part of the traffic light analogy that unit tests follow, but doesn't imply that the unit tests within the file are passing (green) or failing (red).