### PR TITLE
Added styling for platformio-ide-terminal

### DIFF
--- a/index.less
+++ b/index.less
@@ -26,6 +26,7 @@
 @import "styles/plugins/autocomplete-plus";
 @import "styles/plugins/deprecation-cop";
 @import "styles/plugins/linter";
+@import "styles/plugins/platformio-ide-terminal";
 @import "styles/plugins/terminal-plus";
 @import "styles/plugins/time-cop";
 @import "styles/plugins/tree-view-git-branch";

--- a/styles/plugins/platformio-ide-terminal.less
+++ b/styles/plugins/platformio-ide-terminal.less
@@ -1,0 +1,34 @@
+.platformio-ide-terminal.terminal-view {
+  .input-block {
+    padding-top: 0;
+    padding-right: 0;
+    padding-left: 0;
+
+    .btn-toolbar {
+      margin-left: 0;
+      padding: 0;
+    }
+
+    .btn-group {
+      margin: 0;
+    }
+
+    .btn {
+      width: 45px;
+      height: 35px;
+      padding: 0;
+      background-color: @tab-background-color-active;
+    }
+
+    .btn::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translateX(-50%) translateY(-50%);
+    }
+
+    .btn.icon-screen-full::before {
+      top: 15px;
+    }
+  }
+}


### PR DESCRIPTION
The `platformio-ide-terminal` plugin was a little bit messy with `seti-ui`, so I styled it to make it more consistent.

Old :
![screenshot from 2018-02-15 22-25-20](https://user-images.githubusercontent.com/2735603/36292361-4b979302-129f-11e8-8b57-8ed0db6909f9.png)
New :
![screenshot from 2018-02-15 22-25-01](https://user-images.githubusercontent.com/2735603/36292359-49405008-129f-11e8-953d-e71a5d93b540.png)

