### PR TITLE
Map CHANGES.md the same way CHANGELOG.md is mapped

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -194,6 +194,7 @@
 .icon-set('CHANGELOG', 'clock', @blue);
 .icon-set('VERSION.md', 'clock', @blue);
 .icon-set('VERSION', 'clock', @blue);
+.icon-set('CHANGES.md', 'clock', @blue);
 
 // MAVEN
 .icon-set('mvnw', 'maven', @red);


### PR DESCRIPTION
I often see `CHANGES.md` used instead of `CHANGELOG.md`, so I'd like to propose mapping it the same way. I feel like the mapping is universal enough to not have any unintended consequences.