### PR TITLE
catch more webpack filenames

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -472,10 +472,7 @@
 .icon-set('yarn.lock', 'yarn', @blue);
 
 // WEBPACK
-.icon-set('webpack.config.js', 'webpack', @blue);
-.icon-set('webpack.config.build.js', 'webpack', @blue);
-.icon-set('webpack.config.js', 'webpack', @blue);
-
+.icon-set('webpack.*', 'webpack', @blue);
 
 // MISC SETTING
 .icon-set('.direnv', 'config', @grey-light);


### PR DESCRIPTION
It doesn't seem like wildcards are supported here, but examples of filenames I'd like to support:
- webpack.common.js
- webpack.common.ts
- webpack.server.js
- webpack.browser.ts
etc....

I'm happy to make the appropriate change if someone can point me in the right direction