### PR TITLE
Add .test.js and .test.ts as test extensions (same as .spec.js/ts)

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -157,6 +157,7 @@
 .icon-set(".js", "javascript", @yellow);
 .icon-set(".js.map", "javascript", @yellow);
 .icon-set(".spec.js", "javascript", @orange);
+.icon-set(".test.js", "javascript", @orange);
 .icon-set(".es", "javascript", @yellow);
 .icon-set(".es5", "javascript", @yellow);
 .icon-set(".es6", "javascript", @yellow);
@@ -332,6 +333,7 @@
 // TYPESCRIPT
 .icon-set(".ts", "typescript", @blue);
 .icon-set(".spec.ts", "typescript", @yellow);
+.icon-set(".test.ts", "typescript", @yellow);
 
 // VALA
 .icon-set(".vala", "vala", @grey-light);


### PR DESCRIPTION
Hey @jesseweed, thanks for the kick-ass icons!

Me and lots of devs prefer `.test.js` over `.spec.js` (or `.ts`), this duplicates the `.spec.` definitions to `.test.` suffixes.