### PR TITLE
Update icon colors for js, ts, jsx, and tsx tests

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -167,6 +167,7 @@
 .icon-set(".js", "javascript", @yellow);
 .icon-set(".js.map", "javascript", @yellow);
 .icon-set(".spec.js", "javascript", @orange);
+.icon-set(".test.js", "javascript", @orange);
 .icon-set(".es", "javascript", @yellow);
 .icon-set(".es5", "javascript", @yellow);
 .icon-set(".es6", "javascript", @yellow);
@@ -281,8 +282,12 @@
 
 // REACT
 .icon-set(".jsx", "react", @blue);
+.icon-set(".spec.jsx", "react", @orange);
+.icon-set(".test.jsx", "react", @orange);
 .icon-set(".cjsx", "react", @blue);
 .icon-set(".tsx", "react", @blue);
+.icon-set(".spec.tsx", "react", @yellow);
+.icon-set(".test.tsx", "react", @yellow);
 
 // REASONML
 .icon-set(".re", "reasonml", @red);
@@ -354,8 +359,6 @@
 .icon-set(".ts", "typescript", @blue);
 .icon-set(".spec.ts", "typescript", @yellow);
 .icon-set(".test.ts", "typescript", @yellow);
-.icon-set(".spec.tsx", "typescript", @yellow);
-.icon-set(".test.tsx", "typescript", @yellow);
 
 // TSCONFIG
 .icon-set("tsconfig.json", "tsconfig", @blue);


### PR DESCRIPTION
This PR aims to standardize the colors and icons of JavaScript and TypeScript test files, building on #530. Below is a before-and-after of what the icons look like with this PR.

| Before | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/25592344/61259329-bbfdcd80-a747-11e9-9cc8-6e81fa179609.png) | ![image](https://user-images.githubusercontent.com/25592344/61259354-d59f1500-a747-11e9-8b68-0535918af197.png) |