### PR TITLE
Add Docker icon for docker-compose.override file

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -481,6 +481,8 @@
 .icon-partial("docker-healthcheck", "docker", @green);
 .icon-partial("docker-compose.yml", "docker", @pink);
 .icon-partial("docker-compose.yaml", "docker", @pink);
+.icon-partial("docker-compose.override.yml", "docker", @pink);
+.icon-partial("docker-compose.override.yaml", "docker", @pink);
 
 // BABEL
 .icon-set(".codeclimate.yml", "code-climate", @green);


### PR DESCRIPTION
`docker-compose.override.yml` is the default name for [multiple compose files](https://docs.docker.com/compose/extends/)