### PR TITLE
Update mapping.less - .litcoffee

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -57,6 +57,7 @@
 
 // COFFEESCRIPT
 .icon-set(".coffee", "coffee", @yellow);
+.icon-set(".litcoffee", "coffee", @yellow);
 
 // CONFIG
 .icon-set(".config", "config", @grey-light);


### PR DESCRIPTION
Support for literate coffeescript (`.litcoffee`), cf. [https://coffeescript.org/#literate](https://coffeescript.org/#literate).