### PR TITLE
Make highlighted text readable in the panel

### DIFF
--- a/styles/ui-mixins.less
+++ b/styles/ui-mixins.less
@@ -63,7 +63,7 @@
     }
 
     .highlights .highlight.selection .region {
-      background: @seti-primary;
+      background: @seti-primary-highlight;
       color: @white;
     }
 
@@ -89,7 +89,7 @@
     }
 
     .highlights .highlight.selection .region {
-      background: @seti-primary;
+      background: @seti-primary-highlight;
       color: @seti-primary-text !important;
     }
 

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -112,8 +112,8 @@
 
 // BACKGROUND
 @background-color-highlight: @seti-primary;
-@background-color-selected: @seti-primary;
-@background-color-info: @seti-primary;
+@background-color-selected: @seti-primary-highlight;
+@background-color-info: @seti-primary-highlight;
 @background-color-success: @green;
 @background-color-warning: @yellow;
 @background-color-error: @red;


### PR DESCRIPTION
Highlighted text in the search field of the find & replace panel used the same color for the background and the text, making it unreadable. Changed the background color to @seti-primary-highlight.