### PR TITLE
add gulpfile.js to use the gulp icon

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -517,6 +517,7 @@
 .icon-partial("GULPFILE", "gulp", @red);
 .icon-partial("Gulpfile", "gulp", @red);
 .icon-partial("gulpfile", "gulp", @red);
+.icon-partial("gulpfile.js", "gulp", @red);
 
 // IONIC
 .icon-set("ionic.config.json", "ionic", @blue);


### PR DESCRIPTION
gulp-cli 2.2.0 with gulp 4.0.2 do by default use a file named `gulpfile.js` and complain about a missing one, if only a `gulpfile` exists. So I'd say it would be pretty useful to support the standard.

Partly fixes #422 