### PR TITLE
Fix rmd category as R

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -295,7 +295,7 @@
 
 // R
 .icon-set('.R', 'R', @blue);
-.icon-set('.rmd', 'rmd', @blue);
+.icon-set('.rmd', 'R', @blue);
 
 // RUBY
 .icon-set(".rb", "ruby", @red);


### PR DESCRIPTION
Sorry, the previous PR #563 was wrong, that did not identify rmd file as R.
This PR identifies rmd file as the R.