### PR TITLE
Fix missing icons for TIFF and WebP images

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -424,6 +424,8 @@
 .icon-set(".pxm", "image", @purple);
 .icon-set(".svg", "svg", @purple);
 .icon-set(".svgx", "image", @purple);
+.icon-set(".tiff", "image", @purple);
+.icon-set(".webp", "image", @purple);
 
 // SUBLIME
 .icon-set(".sublime-project", "sublime", @orange);


### PR DESCRIPTION
WebP and TIFF images are currently using the default text icon.
This change only adds both image extensions to the icon list.