### PR TITLE
.tsx icon fix

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -288,6 +288,7 @@
 
 // REACT
 .icon-set(".jsx", "react", @blue);
+.icon-set(".tsx", "react", @blue);
 .icon-set(".spec.jsx", "react", @orange);
 .icon-set(".test.jsx", "react", @orange);
 .icon-set(".cjsx", "react", @blue);
@@ -363,7 +364,6 @@
 
 // TYPESCRIPT
 .icon-set(".ts", "typescript", @blue);
-.icon-set(".tsx", "typescript", @blue);
 .icon-set(".spec.ts", "typescript", @yellow);
 .icon-set(".test.ts", "typescript", @yellow);
 


### PR DESCRIPTION
.tsx files are currently associated to "typescript", so it is displaying the regular "ts" icon instead of the React one. This is a fix to it