### PR TITLE
Use smarty icon for .tpl

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -322,6 +322,7 @@
 
 // SMARTY
 .icon-set(".smarty.tpl", "smarty", @yellow);
+.icon-set(".tpl", "smarty", @yellow);
 
 // SBT
 .icon-set(".sbt", "sbt", @blue);


### PR DESCRIPTION
Smarty uses `.tpl` as the [default extension](https://github.com/smarty-php/smarty/blob/4f7cd8f1b3e29b108d6eee28e912149f8d8ad893/libs/sysplugins/smarty_internal_method_compilealltemplates.php#L36). 

