### PR TITLE
Add .graphqls extension for GraphQL

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -138,6 +138,7 @@
 // GRAPHQL
 .icon-set(".gql", "graphql", @pink);
 .icon-set(".graphql", "graphql", @pink);
+.icon-set(".graphqls", "graphql", @pink);
 
 // HAML
 .icon-set(".haml", "haml", @red);


### PR DESCRIPTION
Some graphql tools are now using `.graphqls` to differentiate between front-end `.graphql` files and back-end `.graphqls` files (which are normally fragments of a larger schema.

Example: Adobe Magento uses `.graphqls` files to split up the schema of their modules (https://devdocs.magento.com/guides/v2.4/graphql/develop/create-graphqls-file.html)