### PR TITLE
Extend Ruby icon support for Gemfile formats

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -307,6 +307,10 @@
 
 // RUBY
 .icon-set(".rb", "ruby", @red);
+.icon-partial("Gemfile", "ruby", @red);
+.icon-partial("gemfile", "ruby", @red);
+.icon-partial("Rakefile", "ruby", @red);
+.icon-partial("rakefile", "ruby", @red);
 .icon-set(".erb", "html_erb", @red);
 .icon-set(".erb.html", "html_erb", @red);
 .icon-set(".html.erb", "html_erb", @red);

--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -309,8 +309,6 @@
 .icon-set(".rb", "ruby", @red);
 .icon-partial("Gemfile", "ruby", @red);
 .icon-partial("gemfile", "ruby", @red);
-.icon-partial("Rakefile", "ruby", @red);
-.icon-partial("rakefile", "ruby", @red);
 .icon-set(".erb", "html_erb", @red);
 .icon-set(".erb.html", "html_erb", @red);
 .icon-set(".html.erb", "html_erb", @red);


### PR DESCRIPTION
Hi, I am VS Code user using the vs-seti theme.

I noticed that the `Gemfile` file doesn't have a Ruby icon and so I added one by updating the mapping file. I based changes on the Makefile pattern at the end of the file (using `.icon-partial` to match on filename and adding two rows to handle the case).

VS Code already recognizes a bunch of files like `.rbx`, `.gemspec` and `Rakefile` as Ruby and gives them the correct icon, so I didn't change those.

Thanks