### PR TITLE
Add `.mll` and `.mly` mappings to OCaml

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -275,6 +275,8 @@
 // OCAML
 .icon-set(".ml", "ocaml", @orange);
 .icon-set(".mli", "ocaml", @orange);
+.icon-set(".mll", "ocaml", @orange);
+.icon-set(".mly", "ocaml", @orange);
 .icon-set(".cmx", "ocaml", @orange);
 .icon-set(".cmxa", "ocaml", @orange);
 


### PR DESCRIPTION
These are used by the Menhir parser/lexer generator, and `ocamlyacc`.