### PR TITLE
[Proposal] Change Typescript Test Colours

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -322,8 +322,8 @@
 .icon-set(".spec.jsx", "react", @orange);
 .icon-set(".test.jsx", "react", @orange);
 .icon-set(".cjsx", "react", @blue);
-.icon-set(".spec.tsx", "react", @yellow);
-.icon-set(".test.tsx", "react", @yellow);
+.icon-set(".spec.tsx", "react", @orange);
+.icon-set(".test.tsx", "react", @orange);
 
 // REASONML
 .icon-set(".re", "reasonml", @red);
@@ -408,8 +408,8 @@
 // TYPESCRIPT
 .icon-set(".ts", "typescript", @blue);
 .icon-set(".tsx", "typescript", @blue);
-.icon-set(".spec.ts", "typescript", @yellow);
-.icon-set(".test.ts", "typescript", @yellow);
+.icon-set(".spec.ts", "typescript", @orange);
+.icon-set(".test.ts", "typescript", @orange);
 
 // TSCONFIG
 .icon-set("tsconfig.json", "tsconfig", @blue);


### PR DESCRIPTION
Hi, I'd like to propose that the Typescript test files (`.test.ts`, `.test.tsx`, `.spec.ts`, `.spec.tsx`) are changed from `@yellow` to `@orange`.
The main motivation is that yellow TS looks incredibly similar to a normal JS file. JS test files use orange, so it'd be consistent with that too.

Thanks!