### PR TITLE
Use ESLint icon for .eslintrc.cjs

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -556,6 +556,7 @@
 // ESLINT
 .icon-set(".eslintrc", "eslint", @purple);
 .icon-set(".eslintrc.js", "eslint", @purple);
+.icon-set(".eslintrc.cjs", "eslint", @purple);
 .icon-set(".eslintrc.yaml", "eslint", @purple);
 .icon-set(".eslintrc.yml", "eslint", @purple);
 .icon-set(".eslintrc.json", "eslint", @purple);


### PR DESCRIPTION
As per https://eslint.org/docs/user-guide/configuring/configuration-files#configuration-file-formats, please use the ESLint icon for `.eslintrc.cjs`.