### PR TITLE
Adding Hjson mapping to json icon

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -180,6 +180,9 @@
 .icon-set(".hxp", "haxe", @blue);
 .icon-set(".hxml", "haxe", @purple);
 
+// HJSON
+.icon-set(".hjson", "json", @yellow);
+
 // HTML
 .icon-set(".html", "html", @orange);
 


### PR DESCRIPTION
## Summary

Hjson project by @laktak: https://hjson.github.io/
VSCode extension with 10k+ downloads: https://marketplace.visualstudio.com/items?itemName=laktak.hjson

## Preview
Would use the same icon as json and jsonc files:

![hjson-icon-preview-screenshot](https://user-images.githubusercontent.com/64347790/133517592-f3b9c04b-80f3-4369-8596-b1ed245e323f.png)
