### PR TITLE
Simplify bazel.svg to remove visual artifacts

### DIFF
--- a/icons/bazel.svg
+++ b/icons/bazel.svg
@@ -1,1 +1,1 @@
-<svg viewBox="0 0 512 512" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><path fill="#43a047" d="M184 112l72 72-72 72-72-72z"/><path fill="#43a047" d="M112 184v72l72 72v-72zm216-72l72 72-72 72-72-72z"/><path fill="#43a047" d="M400 184v72l-72 72v-72zm-144 0l72 72-72 72-72-72z"/><path fill="#43a047" d="M256 328v72l-72-72v-72zm0 0l72-72v72l-72 72z"/></svg>
+<svg viewBox="0 0 512 512" width="32" height="32" xmlns="http://www.w3.org/2000/svg"><path fill="#43a047" d="M184 112l72 72 72-72 72 72 0 72-144 144-144-144 0-72z"/></svg>


### PR DESCRIPTION
Because of how the icon was split into multiple tiles, it would sometimes render with a gap in the middle of the icon. I noticed this when the icon was added to VSCode 1.61, where it looks like this: 
![image](https://user-images.githubusercontent.com/1205857/137544291-6d2d8eca-a0de-4c52-b642-175b20999b85.png)
This change simplifies the svg to a single path, so there can't be gaps in the middle.
