### PR TITLE
Add icon mapping for webpack.config.cjs, .etc

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -633,10 +633,15 @@
 
 // WEBPACK
 .icon-set("webpack.config.js", "webpack", @blue);
+.icon-set("webpack.config.cjs", "webpack", @blue);
 .icon-set("webpack.config.build.js", "webpack", @blue);
+.icon-set("webpack.config.build.cjs", "webpack", @blue);
 .icon-set("webpack.common.js", "webpack", @blue);
+.icon-set("webpack.common.cjs", "webpack", @blue);
 .icon-set("webpack.dev.js", "webpack", @blue);
+.icon-set("webpack.dev.cjs", "webpack", @blue);
 .icon-set("webpack.prod.js", "webpack", @blue);
+.icon-set("webpack.prod.cjs", "webpack", @blue);
 
 // MISC SETTING
 .icon-set(".direnv", "config", @grey-light);


### PR DESCRIPTION
Before this change, Webpack config files would not use the Webpack icon if the extension was `.cjs`.

This brings Webpack in line with other config files like `.babelrc` and `.eslintrc` that already had icon mappings for the `.cjs` extension.