### PR TITLE
Add `.bazelignore` and `.bazelversion` to icon mappings

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -33,6 +33,8 @@
 .icon-set(".bazel", "bazel", @green);
 .icon-set(".BUILD", "bazel", @green);
 .icon-set(".WORKSPACE", "bazel", @green);
+.icon-set(".bazelignore", "bazel", @green);
+.icon-set(".bazelversion", "bazel", @green);
 
 // C
 .icon-set(".c", "c", @blue);


### PR DESCRIPTION
`.bazelignore` and `.bazelversion` files were not previously using the bazel icon.

[.bazelignore documentation](https://docs.bazel.build/versions/main/guide.html#bazelignore)
[.bazelversion documentation](https://docs.bazel.build/versions/main/guide.html#bazelignore)