### PR TITLE
Add more extensions to documentation files

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -247,12 +247,18 @@
 
 // README
 .icon-set("README.md", "info", @blue);
+.icon-set("README.txt", "info", @blue);
+.icon-set("README", "info", @blue);
 
 // CHANGELOG
 .icon-set('CHANGELOG.md', 'clock', @blue);
+.icon-set('CHANGELOG.txt', 'clock', @blue);
 .icon-set('CHANGELOG', 'clock', @blue);
 .icon-set('CHANGES.md', 'clock', @blue);
+.icon-set('CHANGES.txt', 'clock', @blue);
+.icon-set('CHANGES', 'clock', @blue);
 .icon-set('VERSION.md', 'clock', @blue);
+.icon-set('VERSION.txt', 'clock', @blue);
 .icon-set('VERSION', 'clock', @blue);
 
 // MAVEN
@@ -666,11 +672,19 @@
 // LICENSE FILES
 .icon-partial("LICENSE", "license", @yellow);
 .icon-partial("LICENCE", "license", @yellow);
+.icon-partial("LICENSE.txt", "license", @yellow);
+.icon-partial("LICENCE.txt", "license", @yellow);
 .icon-partial("LICENSE.md", "license", @yellow);
 .icon-partial("LICENCE.md", "license", @yellow);
 .icon-partial("COPYING", "license", @yellow);
+.icon-partial("COPYING.txt", "license", @yellow);
+.icon-partial("COPYING.md", "license", @yellow);
 .icon-partial("COMPILING", "license", @orange);
+.icon-partial("COMPILING.txt", "license", @orange);
+.icon-partial("COMPILING.md", "license", @orange);
 .icon-partial("CONTRIBUTING", "license", @red);
+.icon-partial("CONTRIBUTING.txt", "license", @red);
+.icon-partial("CONTRIBUTING.md", "license", @red);
 
 // MAKEFILES
 .icon-partial("MAKEFILE", "makefile", @orange);
@@ -692,6 +706,8 @@
 
 // TODO
 .icon-partial("TODO", "todo", @seti-primary);
+.icon-partial("TODO.txt", "todo", @seti-primary);
+.icon-partial("TODO.md", "todo", @seti-primary);
 
 // - - - - - - -
 // IGNORED FILES


### PR DESCRIPTION
This is a transfer from microsoft/vscode#144144. For convenience, I copied the issue and PR descriptions in here.

---

Certain files, like CHANGELOG, CONTRIBUTING, TODO etc. have special icons. However, if they are suffixed with `.md` or `.txt`, they sometimes no longer have their icons.

I would like that such special files also have those icons when they have extensions in their names; many OSes support linking a program to open files with certain extensions (e. g. a markdown reader for .md, or a text editor for .txt). Although VSCode does not have this problem, many of my users use the regular Notepad to read those files; for their convenience, I need to append all my documentation files with .txt (or .md) so that they can easily open those files in their preferred program.

For convenience, here are the pairings that have special icons:

| File name | .md | .txt | (no extension) |
| --- | --- | --- | --- |
| Readme | x |  |  |
| Changelog | x |  | x |
| Changes | x |  |  |
| Version | x |  | x |
| Licen[cs]e | x |  | x |
| Copying |  |  | x |
| Compiling |  |  | x |
| Contributing |  |  | x |
| Todo |  |  | x |

I would like to propose to make it so all pairings have the special icon corresponding to the file name.

I added every combination; if certain pairings are accepted but others rejected, I am open to remove them. I also left "Allow edits by maintainers" checked, so edits can be pushed directly to this PR if necessary.

I believe .txt and .md are the only two extensions commonly used for this type of files, but if other extensions are known, I'm open to add them in this PR.