### PR TITLE
different colors for .class and .java

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -190,7 +190,7 @@
 
 // JAVA
 .icon-set(".java", "java", @red);
-.icon-set(".class", "java", @red);
+.icon-set(".class", "java", @blue);
 .icon-set(".classpath", "java", @red);
 .icon-set(".properties", "java", @red);
 


### PR DESCRIPTION
Java classes often end up in the same directory as their source files, if their names are to long they are hard to keep apart in the file browser. #647 