### PR TITLE
Update Terraform icon

### DIFF
--- a/icons/terraform.svg
+++ b/icons/terraform.svg
@@ -1,1 +1,6 @@
-<svg width="32" height="32" xmlns="http://www.w3.org/2000/svg"><path d="M12.5 9l6.63 3.338V19l-6.63-3.37M27.13 9l-6.63 3.338V19l6.63-3.37M4.5 5l6.63 3.338V15L4.5 11.63m8 5.37l6.63 3.338V27l-6.63-3.37" fill-rule="evenodd"/></svg>
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.5066 8.01531L19.2375 12.1073V20.2894L12.5066 16.1992V8.01531Z" fill="#7B42BC"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0294 12.1073V20.2894L27.1563 16.1992V8.01531L20.0294 12.1073Z" fill="#7B42BC"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.58781 3.66V11.5787L11.7147 15.5381V7.61937L4.58781 3.66Z" fill="#7B42BC"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12.5066 25.04L19.2375 29V21.1348V21.0818L12.5066 17.1219V25.04Z" fill="#7B42BC"/>
+</svg>


### PR DESCRIPTION
This updates the icon to the latest version as per brand guidelines https://www.hashicorp.com/brand#terraform
It doesn't _exactly_ match the guidelines in terms of the exact shade of purple, but respecting the rest of the ecosystem, as per [Contributing guidelines](https://github.com/jesseweed/seti-ui/blob/master/CONTRIBUTING.md) also seems important

> While, you can add additional colors to [styles/ui-variable.less](https://github.com/jesseweed/seti-ui/blob/master/styles/ui-variable.less), but please do not do this unless you find it absolutely necessary.

- predefined `purple` is `#a074c4`
- Terraform logo would be `#7B42BC`

Let me know if you'd be willing to accept that change of purple shade and I can update it as well.

As for the shape there was a minor change in spacing between the segments.

![Screenshot 2022-07-08 at 08 47 32](https://user-images.githubusercontent.com/287584/177958566-e0c38db0-b656-4f50-b9d3-724fa3cc6a96.png)

## Before vs After

Top 2 icons are before, bottom 2 are after.

**VS Code**
![Screenshot 2022-07-08 at 10 01 37](https://user-images.githubusercontent.com/287584/177957701-ae26d764-f305-41d0-b557-a04348350514.png)

**Atom**
![Screenshot 2022-07-08 at 08 51 48](https://user-images.githubusercontent.com/287584/177957704-eb35bf2a-2c89-470e-aa3b-6ca6c1f5a09f.png)
