### PR TITLE
Update mapping.less: support webpack config in TypeScript

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -649,14 +649,19 @@
 // WEBPACK
 .icon-set("webpack.config.js", "webpack", @blue);
 .icon-set("webpack.config.cjs", "webpack", @blue);
+.icon-set("webpack.config.ts", "webpack", @blue);
 .icon-set("webpack.config.build.js", "webpack", @blue);
 .icon-set("webpack.config.build.cjs", "webpack", @blue);
+.icon-set("webpack.config.build.ts", "webpack", @blue);
 .icon-set("webpack.common.js", "webpack", @blue);
 .icon-set("webpack.common.cjs", "webpack", @blue);
+.icon-set("webpack.common.ts", "webpack", @blue);
 .icon-set("webpack.dev.js", "webpack", @blue);
 .icon-set("webpack.dev.cjs", "webpack", @blue);
+.icon-set("webpack.dev.ts", "webpack", @blue);
 .icon-set("webpack.prod.js", "webpack", @blue);
 .icon-set("webpack.prod.cjs", "webpack", @blue);
+.icon-set("webpack.prod.ts", "webpack", @blue);
 
 // MISC SETTING
 .icon-set(".direnv", "config", @grey-light);


### PR DESCRIPTION
Webpack supports configuration files written in TypeScript: [webpack docs / Configuration Languages](https://webpack.js.org/configuration/configuration-languages/#typescript). So it would be nice to show webpack icons for these files too!

Actually I want to update [theme-seti in VS Code](https://github.com/microsoft/vscode/blob/main/extensions/theme-seti/README.md) 😺 