### PR TITLE
Add rollup icon to rollup.config.mjs

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -628,6 +628,7 @@
 
 // ROLLUP
 .icon-set("rollup.config.js", "rollup", @red);
+.icon-set("rollup.config.mjs", "rollup", @red);
 
 // SASS LINT
 .icon-set("sass-lint.yml", "sass", @pink);


### PR DESCRIPTION
With rollup 3, now it's possible to use a module instead of cjs