### PR TITLE
Add obscure Excel-formats to mapping.less

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -94,8 +94,6 @@
 
 // CSV
 .icon-set(".csv", "csv", @green);
-.icon-set(".xls", "xls", @green);
-.icon-set(".xlsx", "xls", @green);
 
 // CUDA
 .icon-set(".cu", "cu", @green);
@@ -123,6 +121,20 @@
 
 // ELM
 .icon-set(".elm", "elm", @blue);
+
+// EXCEL
+.icon-set(".xlsx", "xls", @green);
+.icon-set(".xlsm", "xls", @green);
+.icon-set(".xlsb", "xls", @green);
+.icon-set(".xltx", "xls", @green);
+.icon-set(".xltm", "xls", @green);
+.icon-set(".xls", "xls", @green);
+.icon-set(".xlt", "xls", @green);
+.icon-set(".xls", "xls", @green);
+.icon-set(".xlam", "xls", @green);
+.icon-set(".xla", "xls", @green);
+.icon-set(".xlw", "xls", @green);
+.icon-set(".xlr", "xls", @green);
 
 // FAVICON
 .icon-set(".ico", "favicon", @yellow);


### PR DESCRIPTION
Noticed this omission while working with xltx-files, figured I might as well fix it.

I used [this](https://support.microsoft.com/en-us/office/file-formats-that-are-supported-in-excel-0943ff2c-6014-4e8d-aaea-b83d51d46247) list of Excel's supported file extensions.