### PR TITLE
Use Jenkins icon on files with `.Jenkinsfile` extension

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -546,6 +546,7 @@
 
 // CI
 .icon-set("Jenkinsfile", "jenkins", @red);
+.icon-set(".Jenkinsfile", "jenkins", @red);
 
 // BABEL
 .icon-set(".babelrc", "babel", @yellow);


### PR DESCRIPTION
Classic convention for extra Jenkins pipeline files.