### PR TITLE
chore: use audio icon for mid files

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -522,6 +522,7 @@
 .icon-set(".mp4", "video", @pink);
 
 // AUDIO FILES
+.icon-set('.mid', 'audio', @purple);
 .icon-set('.mp3', 'audio', @purple);
 .icon-set('.ogg', 'audio', @purple);
 .icon-set('.wav', 'audio', @purple);


### PR DESCRIPTION
For MIDI files:
https://en.wikipedia.org/wiki/MIDI

Operating systems tend to give it the same icon as wav, mp3, etc as well.