### PR TITLE
Add .otf mapping to generic font file

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -486,6 +486,7 @@
 .icon-set(".ttf", "font", @red);
 .icon-set(".woff", "font", @red);
 .icon-set(".woff2", "font", @red);
+.icon-set(".otf", "font", @red);
 
 // IMAGE FILES
 .icon-set(".avif", "image", @purple);


### PR DESCRIPTION
Add .otf mapping to generic "font". Resolves #694

- Before: 

![image](https://github.com/jesseweed/seti-ui/assets/48109042/0aa27f16-76f4-454c-9ffe-8f53a56d86d1)

- After:

![image](https://github.com/jesseweed/seti-ui/assets/48109042/baa63a80-d272-4911-b4b9-9a27d9c01670)
