### PR TITLE
Webpack icon: support .mjs file extension

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -651,18 +651,23 @@
 // WEBPACK
 .icon-set("webpack.config.js", "webpack", @blue);
 .icon-set("webpack.config.cjs", "webpack", @blue);
+.icon-set("webpack.config.mjs", "webpack", @blue);
 .icon-set("webpack.config.ts", "webpack", @blue);
 .icon-set("webpack.config.build.js", "webpack", @blue);
 .icon-set("webpack.config.build.cjs", "webpack", @blue);
+.icon-set("webpack.config.build.mjs", "webpack", @blue);
 .icon-set("webpack.config.build.ts", "webpack", @blue);
 .icon-set("webpack.common.js", "webpack", @blue);
 .icon-set("webpack.common.cjs", "webpack", @blue);
+.icon-set("webpack.common.mjs", "webpack", @blue);
 .icon-set("webpack.common.ts", "webpack", @blue);
 .icon-set("webpack.dev.js", "webpack", @blue);
 .icon-set("webpack.dev.cjs", "webpack", @blue);
+.icon-set("webpack.dev.mjs", "webpack", @blue);
 .icon-set("webpack.dev.ts", "webpack", @blue);
 .icon-set("webpack.prod.js", "webpack", @blue);
 .icon-set("webpack.prod.cjs", "webpack", @blue);
+.icon-set("webpack.prod.mjs", "webpack", @blue);
 .icon-set("webpack.prod.ts", "webpack", @blue);
 
 // MISC SETTING


### PR DESCRIPTION
As of v4.5.0, webpack-cli supports configs with `.mjs` file extension: https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%404.5.0

This PR updates Seti theme to use the webpack icon for such files instead of the generic JS file icon.