### PR TITLE
feat: add .bats file type to shell

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -531,6 +531,7 @@
 .icon-set(".fish", "shell", @green);
 .icon-set(".zshrc", "shell", @green);
 .icon-set(".bashrc", "shell", @green);
+.icon-set(".bats", "shell", @green);
 
 // VIDEO FILES
 .icon-set(".mov", "video", @pink);


### PR DESCRIPTION
Adds the `.bats` file type and maps it to shell.

BATS (Bash Automated Testing System) is a notable project with > 5k stars on GitHub. ⭐
Given the type of file it is, of the existing icons, shell is the most appropriate.

---

They do technically have their own icon, so it would be even better if `.bats` was specifically bound to the bats icon, however not sure if it's worth including the icon in this theme. Thoughts welcome!

* https://github.com/bats-core/bats-core/blob/master/docs/source/assets/light_mode_bat.svg
* https://github.com/bats-core/bats-core/blob/master/docs/source/assets/dark_mode_bat.svg