### PR TITLE
recognise `UNLICENSE`/`UNLICENCE` `.md/.txt/<empty>` license files

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -711,6 +711,12 @@
 .icon-partial("LICENCE.txt", "license", @yellow);
 .icon-partial("LICENSE.md", "license", @yellow);
 .icon-partial("LICENCE.md", "license", @yellow);
+.icon-partial("UNLICENSE", "license", @yellow);
+.icon-partial("UNLICENCE", "license", @yellow);
+.icon-partial("UNLICENSE.txt", "license", @yellow);
+.icon-partial("UNLICENCE.txt", "license", @yellow);
+.icon-partial("UNLICENSE.md", "license", @yellow);
+.icon-partial("UNLICENCE.md", "license", @yellow);
 .icon-partial("COPYING", "license", @yellow);
 .icon-partial("COPYING.txt", "license", @yellow);
 .icon-partial("COPYING.md", "license", @yellow);


### PR DESCRIPTION
PR from this issue: https://github.com/jesseweed/seti-ui/issues/581