### PR TITLE
Add additional eslint config file assocations

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -610,6 +610,11 @@
 .icon-set(".eslintrc.json", "eslint", @purple);
 .icon-set(".eslintignore", "eslint", @grey);
 .icon-set("eslint.config.js", "eslint", @purple);
+.icon-set("eslint.config.mjs", "eslint", @purple);
+.icon-set("eslint.config.cjs", "eslint", @purple);
+.icon-set("eslint.config.ts", "eslint", @purple);
+.icon-set("eslint.config.mts", "eslint", @purple);
+.icon-set("eslint.config.cts", "eslint", @purple);
 
 // FIREBASE
 .icon-set(".firebaserc", "firebase", @orange);


### PR DESCRIPTION
`eslint@9` adds support for new flat config files, and these new extensions should be reflected in the file associations for eslint.

The new config files are:

- `eslint.config.mjs`
- `eslint.config.cjs`
- `eslint.config.ts`
- `eslint.config.mts`
- `eslint.config.cts`

These file names are gleaned from the eslint v9 documentation itself: https://eslint.org/docs/latest/use/configure/configuration-files#configuration-file