### PR TITLE
feat: Add distinct orange icon for NestJS .e2e-spec.ts files 

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -441,6 +441,7 @@
 .icon-set(".ts", "typescript", @blue);
 .icon-set(".spec.ts", "typescript", @orange);
 .icon-set(".test.ts", "typescript", @orange);
+.icon-set(".e2e-spec.ts", "typescript", @orange);
 
 // TSCONFIG
 .icon-set("tsconfig.json", "tsconfig", @blue);


### PR DESCRIPTION
This commit updates the VS Code file icon extension configuration to display a distinct orange icon for NestJS end-to-end test files (.e2e-spec.ts). Previously, these files were shown with the default blue TypeScript icon, which did not clearly differentiate them from regular TypeScript files.

By assigning an orange color, we enhance visual clarity and make it easier for developers to identify and work with end-to-end test files within their projects. This improves the overall developer experience and workflow.

- Updated file icon associations to use an orange icon for .e2e-spec.ts files.
- Improved visual differentiation between standard TypeScript and end-to-end test files.