### PR TITLE
js mapping: add .tests.([jt]sx|ts|[cm]?js)

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -209,6 +209,9 @@
 .icon-set(".test.js", "javascript", @orange);
 .icon-set(".test.cjs", "javascript", @orange);
 .icon-set(".test.mjs", "javascript", @orange);
+.icon-set(".tests.js", "javascript", @orange);
+.icon-set(".tests.cjs", "javascript", @orange);
+.icon-set(".tests.mjs", "javascript", @orange);
 .icon-set(".es", "javascript", @yellow);
 .icon-set(".es5", "javascript", @yellow);
 .icon-set(".es6", "javascript", @yellow);
@@ -351,10 +354,12 @@
 .icon-set(".jsx", "react", @blue);
 .icon-set(".spec.jsx", "react", @orange);
 .icon-set(".test.jsx", "react", @orange);
+.icon-set(".tests.jsx", "react", @orange);
 .icon-set(".cjsx", "react", @blue);
 .icon-set(".tsx", "react", @blue);
 .icon-set(".spec.tsx", "react", @orange);
 .icon-set(".test.tsx", "react", @orange);
+.icon-set(".tests.tsx", "react", @orange);
 
 // REASONML
 .icon-set(".re", "reasonml", @red);
@@ -441,6 +446,7 @@
 .icon-set(".ts", "typescript", @blue);
 .icon-set(".spec.ts", "typescript", @orange);
 .icon-set(".test.ts", "typescript", @orange);
+.icon-set(".tests.ts", "typescript", @orange);
 
 // TSCONFIG
 .icon-set("tsconfig.json", "tsconfig", @blue);


### PR DESCRIPTION
Since test files may contain more than 1 test, it is possible for some projects use the `*.tests.*` extension instead of the already mapped `*.test.*`. Add the plural version.

This resolves #718 