### PR TITLE
Map to actual editorconfig icon

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -694,7 +694,7 @@
 .icon-set(".direnv", "config", @grey-light);
 .icon-set(".env", "config", @grey-light);
 .icon-set(".static", "config", @grey-light);
-.icon-set(".editorconfig", "config", @grey-light);
+.icon-set(".editorconfig", "editorconfig", @grey-light);
 .icon-set(".slugignore", "config", @grey-light);
 .icon-set(".tmp", "clock", @grey-light);
 .icon-set(".htaccess", "config", @grey-light);


### PR DESCRIPTION
The editorconfig icon was already present in the theme, but was unused.