### PR TITLE
Support glTF files

### DIFF
--- a/styles/components/icons/mapping.less
+++ b/styles/components/icons/mapping.less
@@ -552,6 +552,8 @@
 .icon-set('.stl', 'svg', @blue);
 .icon-set('.obj', 'svg', @blue);
 .icon-set('.dae', 'svg', @blue);
+.icon-set('.gltf', 'svg', @blue);
+.icon-set('.glb', 'svg', @blue);
 
 // WINDOWS
 .icon-set(".bat", "windows", @blue);


### PR DESCRIPTION
glTF is generally considered the most popular modern 3D file format today, so it'd be nice if seti theme supported it.

This PR adds icon support for glTF file extensions: `.gltf` and `.glb`